### PR TITLE
repetición de días riego Google

### DIFF
--- a/src/front/js/component/CalendarModal.js
+++ b/src/front/js/component/CalendarModal.js
@@ -65,8 +65,34 @@ export const CalendarModal = (props) => {
   const watering = () => {
     const date = new Date();
     date.setDate(date.getDate() + props.diasRiego);
+    date.setHours(8, 0, 0);
 
     return date.toISOString();
+  };
+
+  const recurrence = () => {
+    const date = new Date();
+    date.setFullYear(date.getFullYear() + 1);
+
+    let recurrence =
+      "RRULE:FREQ=DAILY;UNTIL=" +
+      formatDate(date) +
+      ";INTERVAL=" +
+      props.diasRiego;
+
+    console.log(recurrence);
+    return recurrence;
+  };
+
+  const formatDate = (date) => {
+    let month = "" + (date.getMonth() + 1),
+      day = "" + date.getDate(),
+      year = date.getFullYear();
+
+    if (month.length < 2) month = "0" + month;
+    if (day.length < 2) day = "0" + day;
+
+    return [year, month, day].join("");
   };
 
   const submit = () => {
@@ -82,6 +108,8 @@ export const CalendarModal = (props) => {
         dateTime: watering(),
         timeZone: "Europe/Madrid",
       },
+
+      recurrence: [recurrence()],
 
       reminders: {
         useDefault: false,

--- a/src/front/js/component/googleCalendar.js
+++ b/src/front/js/component/googleCalendar.js
@@ -70,6 +70,7 @@ export const signOutFromGoogle = () => {
 export const getSignedInUserEmail = async () => {
   try {
     let status = await checkSignInStatus();
+    console.log(status);
     if (status) {
       var auth2 = gapi.auth2.getAuthInstance();
       var profile = auth2.currentUser.get().getBasicProfile();


### PR DESCRIPTION
Terminé el calendario de Google, ahora se repite el evento cada día de riego según cada planta, y agregué la hora para que todas se coloquen a primera hora.
![Captura de Pantalla 2022-08-15 a las 21 40 41](https://user-images.githubusercontent.com/92450839/184705568-85aa3acf-d3e6-46fc-ba0b-cbe25073f4d5.png)
.